### PR TITLE
Fix interrupt handling with CLI / OUT SREG

### DIFF
--- a/src/avrdevice.h
+++ b/src/avrdevice.h
@@ -78,6 +78,8 @@ class AvrDevice: public SimulationMember, public TraceValueRegister {
         friend class DumpManager;
         void detachDumpManager() { dumpManager = NULL; }
 
+        bool opIsCli(unsigned opcode);
+
     protected:
         SystemClockOffset clockFreq;  ///< Period of a tick (1/F_OSC) in [ns]
         std::map < std::string, Pin *> allPins;

--- a/src/flash.cpp
+++ b/src/flash.cpp
@@ -83,6 +83,13 @@ DecodedInstruction* AvrFlash::GetInstruction(unsigned int pc) {
     return DecodedMem[pc];
 }
 
+unsigned int AvrFlash::GetOpcode(unsigned int pc) {
+    unsigned int addr = pc * 2;
+    if(IsRWWLock(addr))
+        avr_error("flash is locked (RWW lock)");
+    return (myMemory[addr] << 8) + myMemory[addr + 1];
+}
+
 unsigned char AvrFlash::ReadMem(unsigned int offset) {
     if(IsRWWLock(offset)) {
         avr_warning("flash is locked (RWW lock)");

--- a/src/flash.h
+++ b/src/flash.h
@@ -84,6 +84,9 @@ class AvrFlash: public Memory {
         
         /*! Returns instruction at pointer PC. Aborts if Flash write is in progress. */
         DecodedInstruction* GetInstruction(unsigned int pc);
+
+        /*! Returns opcode at PC. Aborts if Flash write is in progress. */
+        unsigned int GetOpcode(unsigned int pc);
         
         /*! Returns byte at flash address. Works even during flash writing. */
         unsigned char ReadMemRaw(unsigned int addr) { return myMemory[addr]; }


### PR DESCRIPTION
When an interrupt is detected and queued to be executed after
the next statement and the next statement is either CLI or any
other instruction that clears the global interrupt flag
(OUT SREG, ...), the interrupt handler will still be called
/after/ global interrupts have been disabled. This  basically
means that code that was meant to be uninterruptible
(protected by CLI / SEI) can now be interrupted as the RETI
will jump back to the first instruction after CLI and will even
leave interrupts enabled.

This change aims to fix the problem by checking the current
instruction before preparing interrupts. If the instructions
will clear the interrupt flag, interrupt preparation will be
skipped.

See also: https://savannah.nongnu.org/bugs/index.php?45941
